### PR TITLE
refactor: add session state validation utilities

### DIFF
--- a/db_handler.py
+++ b/db_handler.py
@@ -8,6 +8,7 @@ from typing import Any, Mapping
 from logging_config import setup_logging
 import time
 from config import DatabaseConfig
+from utils import ss_has, ss_get
 
 mkt_db = DatabaseConfig("wcmkt")
 sde_db = DatabaseConfig("sde")
@@ -275,8 +276,7 @@ def get_all_market_history()->pd.DataFrame:
 
 def get_update_time()->str:
     """Return last local update time as formatted string, handling stale/bool state."""
-    if "local_update_status" in st.session_state:
-        status = st.session_state.local_update_status
+    if status := ss_get("local_update_status"):
         if isinstance(status, dict) and status.get("updated"):
             try:
                 return status["updated"].strftime("%Y-%m-%d | %H:%M UTC")
@@ -361,11 +361,11 @@ def get_4H_price(type_id):
 def new_get_market_data(show_all):
     df = get_all_mkt_orders()
 
-    if 'selected_category_info' in st.session_state and st.session_state.selected_category_info is not None:
-        orders_df = df[df['type_id'].isin(st.session_state.selected_category_info['type_ids'])]
-    if 'selected_item_id' in st.session_state and st.session_state.selected_item_id is not None:
-        logger.debug(f"selected_item_id: {st.session_state.selected_item_id}")
-        orders_df = df[df['type_id'] == st.session_state.selected_item_id]
+    if category_info := ss_get('selected_category_info'):
+        orders_df = df[df['type_id'].isin(category_info['type_ids'])]
+    if selected_item_id := ss_get('selected_item_id'):
+        logger.debug(f"selected_item_id: {selected_item_id}")
+        orders_df = df[df['type_id'] == selected_item_id]
     else:
         orders_df = df
 

--- a/market_metrics.py
+++ b/market_metrics.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta
 import millify
 from services import get_doctrine_service
 import numpy as np
+from utils import ss_has, ss_get, ss_init
 
 logger = setup_logging(__name__)
 
@@ -90,7 +91,7 @@ def wrap_top_n_items(df_7days: pd.DataFrame, df_30days: pd.DataFrame) -> pd.Data
 
     @st.fragment
     def top_n_items_fragment():
-        if "week_month_pill" in st.session_state and "daily_total_pill" in st.session_state and "isk_volume_pill" in st.session_state and "top_items_count" in st.session_state:
+        if ss_has("week_month_pill", "daily_total_pill", "isk_volume_pill", "top_items_count"):
             if df_7days.empty or df_30days.empty:
                 return None
             else:
@@ -673,7 +674,7 @@ def render_top_n_items_ui(df_7days,df_30days)->None:
         isk_volume = "ISK" if st.session_state.isk_volume_pill == 0 else "Volume"
         num_items = st.session_state.top_items_count
 
-        if 'selected_category' in st.session_state and st.session_state.selected_category is not None:
+        if ss_has('selected_category'):
             metric_name = st.session_state.selected_category + "s"
         else:
             metric_name = "Items"
@@ -716,14 +717,14 @@ def render_30day_metrics_ui():
     metrics_category = None
     metrics_item_id = None
 
-    if 'selected_item_id' in st.session_state and st.session_state.selected_item_id is not None:
+    if ss_has('selected_item_id'):
         metrics_item_id = st.session_state.selected_item_id
-    elif 'selected_category' in st.session_state and st.session_state.selected_category is not None:
+    elif ss_has('selected_category'):
         metrics_category = st.session_state.selected_category
 
-    if 'selected_item' in st.session_state and st.session_state.selected_item is not None:
+    if ss_has('selected_item'):
         metrics_label = st.session_state.selected_item
-    elif 'selected_category' in st.session_state and st.session_state.selected_category is not None:
+    elif ss_has('selected_category'):
         metrics_label = st.session_state.selected_category
     else:
         metrics_label = "All Items"
@@ -853,7 +854,7 @@ def render_current_market_status_ui(sell_data, stats, selected_item, sell_order_
     with col2:
         if not sell_data.empty:
             volume = sell_data['volume_remain'].sum()
-            if pd.notna(volume) and 'selected_item' in st.session_state and st.session_state.selected_item is not None:
+            if pd.notna(volume) and ss_has('selected_item'):
                 display_volume = millify.millify(volume, precision=2)
                 st.metric("Market Stock (sell orders)", f"{display_volume}")
             else:

--- a/pages/build_costs.py
+++ b/pages/build_costs.py
@@ -25,7 +25,7 @@ from db_handler import (
     get_4H_price,
     request_type_names,
 )
-from utils import update_industry_index, get_jita_price
+from utils import update_industry_index, get_jita_price, ss_init, ss_has
 import datetime
 import time
 API_TIMEOUT = 20.0
@@ -574,34 +574,21 @@ def check_industry_index_expiry():
 
 def initialise_session_state():
     logger.info("initialising build cost tool")
-    if "sci_expires" not in st.session_state:
-        st.session_state.sci_expires = None
-    if "sci_last_modified" not in st.session_state:
-        st.session_state.sci_last_modified = None
-    if "etag" not in st.session_state:
-        st.session_state.etag = None
-    if "cost_results" not in st.session_state:
-        st.session_state.cost_results = None
-    if "current_job_params" not in st.session_state:
-        st.session_state.current_job_params = None
-    if "selected_item_for_display" not in st.session_state:
-        st.session_state.selected_item_for_display = None
-    if "price_source" not in st.session_state:
-        st.session_state.price_source = None
-    if "price_source_name" not in st.session_state:
-        st.session_state.price_source_name = None
-    if "calculate_clicked" not in st.session_state:
-        st.session_state.calculate_clicked = False
-    if "button_label" not in st.session_state:
-        st.session_state.button_label = "Calculate"
-    if "current_job_params" not in st.session_state:
-        st.session_state.current_job_params = None
-    if "selected_structure" not in st.session_state:
-        st.session_state.selected_structure = None
-    if "super" not in st.session_state:
-        st.session_state.super = False
-    if "async_mode" not in st.session_state:
-        st.session_state.async_mode = False
+    ss_init({
+        "sci_expires": None,
+        "sci_last_modified": None,
+        "etag": None,
+        "cost_results": None,
+        "current_job_params": None,
+        "selected_item_for_display": None,
+        "price_source": None,
+        "price_source_name": None,
+        "calculate_clicked": False,
+        "button_label": "Calculate",
+        "selected_structure": None,
+        "super": False,
+        "async_mode": False,
+    })
     st.session_state.initialised = True
 
     try:

--- a/pages/doctrine_report.py
+++ b/pages/doctrine_report.py
@@ -14,6 +14,7 @@ from logging_config import setup_logging
 from services import get_doctrine_service
 from services.categorization import categorize_ship_by_role
 from ui.formatters import get_doctrine_report_column_config, get_image_url, get_ship_role_format
+from utils import ss_init, ss_get
 
 logger = setup_logging(__name__, log_file=__name__)
 
@@ -27,10 +28,10 @@ def get_module_stock_list(module_names: list):
     """Get lists of modules with their stock quantities for display and CSV export using service."""
 
     # Set the session state variables for the module list and csv module list
-    if not st.session_state.get('module_list_state'):
-        st.session_state.module_list_state = {}
-    if not st.session_state.get('csv_module_list_state'):
-        st.session_state.csv_module_list_state = {}
+    ss_init({
+        'module_list_state': {},
+        'csv_module_list_state': {},
+    })
 
     for module_name in module_names:
         if module_name not in st.session_state.module_list_state:
@@ -242,14 +243,11 @@ def display_low_stock_modules(selected_data: pd.DataFrame, doctrine_modules: pd.
                 st.markdown("<br>", unsafe_allow_html=True)
 
 def main():
-    # Initialize session state for target multiplier
-    if 'target_multiplier' not in st.session_state:
-        st.session_state.target_multiplier = 1.0
-        target_multiplier = st.session_state.target_multiplier
-
-    # Initialize session state for selected modules
-    if 'selected_modules' not in st.session_state:
-        st.session_state.selected_modules = []
+    # Initialize session state for target multiplier and selected modules
+    ss_init({
+        'target_multiplier': 1.0,
+        'selected_modules': [],
+    })
 
     # App title and logo
     # Handle path properly for WSL environment

--- a/pages/doctrine_status.py
+++ b/pages/doctrine_status.py
@@ -12,6 +12,7 @@ from db_handler import get_update_time
 from services import get_doctrine_service, get_price_service
 from domain import StockStatus
 from ui import get_fitting_column_config, render_progress_bar_html
+from utils import ss_init, ss_get
 
 # Insert centralized logging configuration
 logger = setup_logging(__name__, log_file="doctrine_status.log")
@@ -65,10 +66,10 @@ def get_module_stock_list(module_names: list):
     """Get lists of modules with their stock quantities for display and CSV export using service."""
 
     # Set the session state variables for the module list and csv module list
-    if not st.session_state.get('module_list_state'):
-        st.session_state.module_list_state = {}
-    if not st.session_state.get('csv_module_list_state'):
-        st.session_state.csv_module_list_state = {}
+    ss_init({
+        'module_list_state': {},
+        'csv_module_list_state': {},
+    })
 
     for module_name in module_names:
         if module_name not in st.session_state.module_list_state:
@@ -108,10 +109,10 @@ def get_ship_stock_list(ship_names: list):
     Args:
         ship_names: List of ship names to query
     """
-    if not st.session_state.get('ship_list_state'):
-        st.session_state.ship_list_state = {}
-    if not st.session_state.get('csv_ship_list_state'):
-        st.session_state.csv_ship_list_state = {}
+    ss_init({
+        'ship_list_state': {},
+        'csv_ship_list_state': {},
+    })
 
     logger.info(f"Ship names: {ship_names}")
     for ship in ship_names:
@@ -192,8 +193,7 @@ def calculate_all_jita_deltas(force_refresh: bool = False):
     """
     import datetime
 
-    if 'jita_deltas' not in st.session_state:
-        st.session_state.jita_deltas = {}
+    ss_init({'jita_deltas': {}})
 
     # Use service to calculate all jita deltas
     try:
@@ -237,8 +237,7 @@ def main():
 
     # Target multiplier
     ds_target_multiplier = 1.0
-    if 'ds_target_multiplier' not in st.session_state:
-        st.session_state.ds_target_multiplier = ds_target_multiplier
+    ss_init({'ds_target_multiplier': ds_target_multiplier})
     with st.sidebar.expander("Target Multiplier"):
         ds_target_multiplier = st.slider("Target Multiplier", min_value=0.5, max_value=2.0, value=1.0, step=0.1)
         st.session_state.ds_target_multiplier = ds_target_multiplier
@@ -256,12 +255,10 @@ def main():
     unique_ships = sorted(fit_summary["ship_name"].unique().tolist())
 
     # Initialize session state for ship selection if not exists
-    if 'selected_ships' not in st.session_state:
-        st.session_state.selected_ships = []
-
-    # Initialize session state for ship display (showing all ships)
-    if 'displayed_ships' not in st.session_state:
-        st.session_state.displayed_ships = unique_ships.copy()
+    ss_init({
+        'selected_ships': [],
+        'displayed_ships': unique_ships.copy(),
+    })
 
     # Module status filter
     st.sidebar.subheader("Module Filters")
@@ -308,8 +305,7 @@ def main():
         return
 
     # Initialize module selection for export
-    if 'selected_modules' not in st.session_state:
-        st.session_state.selected_modules = []
+    ss_init({'selected_modules': []})
 
     # Group the data by ship_group
     grouped_fits = filtered_df.groupby('ship_group')
@@ -688,7 +684,7 @@ def main():
     st.sidebar.markdown("---")
     st.sidebar.subheader("Jita Price Comparison")
 
-    jita_deltas = st.session_state.get('jita_deltas', {})
+    jita_deltas = ss_get('jita_deltas', {})
 
     if not jita_deltas:
         if st.sidebar.button(

--- a/pages/downloads.py
+++ b/pages/downloads.py
@@ -25,6 +25,7 @@ from logging_config import setup_logging
 from config import DatabaseConfig, get_settings
 from services import get_doctrine_service
 from db_handler import get_all_mkt_orders, get_all_mkt_stats, get_all_market_history, extract_sde_info, read_df
+from utils import ss_get
 
 logger = setup_logging(__name__, log_file="downloads.log")
 
@@ -203,7 +204,7 @@ def market_downloads_section():
         if st.button("Prepare Market Orders", key="prep_orders", use_container_width=True):
             st.session_state.orders_csv_ready = True
 
-        if st.session_state.get('orders_csv_ready'):
+        if ss_get('orders_csv_ready'):
             with st.spinner("Loading market orders..."):
                 csv_data = _get_market_orders_csv()
             st.download_button(
@@ -219,7 +220,7 @@ def market_downloads_section():
         if st.button("Prepare Market Stats", key="prep_stats", use_container_width=True):
             st.session_state.stats_csv_ready = True
 
-        if st.session_state.get('stats_csv_ready'):
+        if ss_get('stats_csv_ready'):
             with st.spinner("Loading market stats..."):
                 csv_data = _get_market_stats_csv()
             st.download_button(
@@ -235,7 +236,7 @@ def market_downloads_section():
         if st.button("Prepare Market History", key="prep_history", use_container_width=True):
             st.session_state.history_csv_ready = True
 
-        if st.session_state.get('history_csv_ready'):
+        if ss_get('history_csv_ready'):
             with st.spinner("Loading market history..."):
                 csv_data = _get_market_history_csv()
             st.download_button(
@@ -282,7 +283,7 @@ def doctrine_downloads_section():
         if st.button("Prepare All Doctrine Fits", key="prep_all_fits", use_container_width=True):
             st.session_state.all_fits_ready = True
 
-        if st.session_state.get('all_fits_ready'):
+        if ss_get('all_fits_ready'):
             with st.spinner("Loading all doctrine fits..."):
                 csv_data = _get_all_doctrine_fits_csv()
             st.download_button(
@@ -306,7 +307,7 @@ def doctrine_downloads_section():
                     st.session_state.filtered_fit_ids = fit_ids
                     st.session_state.filtered_doctrine_name = selected_doctrine
 
-                if st.session_state.get('filtered_fits_ready') and st.session_state.get('filtered_fit_ids') == fit_ids:
+                if ss_get('filtered_fits_ready') and ss_get('filtered_fit_ids') == fit_ids:
                     with st.spinner(f"Loading {selected_doctrine} fits..."):
                         csv_data = _get_filtered_doctrine_csv(fit_ids)
 
@@ -343,7 +344,7 @@ def individual_fit_downloads_section():
             st.session_state.individual_fit_ready = True
             st.session_state.individual_fit_id = fit_id
 
-        if st.session_state.get('individual_fit_ready') and st.session_state.get('individual_fit_id') == fit_id:
+        if ss_get('individual_fit_ready') and ss_get('individual_fit_id') == fit_id:
             with st.spinner("Loading fit data..."):
                 csv_data, ship_name = _get_single_fit_csv(fit_id)
 
@@ -389,7 +390,7 @@ def low_stock_downloads_section():
         st.session_state.low_stock_params = (max_days, doctrine_only, tech2_only)
 
     current_params = (max_days, doctrine_only, tech2_only)
-    if st.session_state.get('low_stock_ready') and st.session_state.get('low_stock_params') == current_params:
+    if ss_get('low_stock_ready') and ss_get('low_stock_params') == current_params:
         with st.spinner("Loading low stock data..."):
             csv_data = _get_low_stock_csv(max_days, doctrine_only, tech2_only)
 
@@ -428,7 +429,7 @@ def sde_downloads_section():
         st.session_state.sde_ready = True
         st.session_state.sde_table = selected_table
 
-    if st.session_state.get('sde_ready') and st.session_state.get('sde_table') == selected_table:
+    if ss_get('sde_ready') and ss_get('sde_table') == selected_table:
         with st.spinner(f"Loading {selected_table}..."):
             csv_data = _get_sde_table_csv(selected_table)
 

--- a/utils.py
+++ b/utils.py
@@ -4,6 +4,56 @@ import streamlit as st
 from logging_config import setup_logging
 import requests
 from config import DatabaseConfig
+from typing import TypeVar, Any, Optional
+
+T = TypeVar('T')
+
+
+# ============================================================================
+# Session State Utilities
+# ============================================================================
+
+def ss_get(key: str, default: T = None) -> Optional[T]:
+    """Get value from session_state if exists and is not None, else return default.
+
+    Args:
+        key: The session state key to retrieve
+        default: Value to return if key doesn't exist or is None
+
+    Returns:
+        The session state value if it exists and is not None, otherwise default
+    """
+    if key in st.session_state:
+        val = st.session_state[key]
+        if val is not None:
+            return val
+    return default
+
+
+def ss_has(*keys: str) -> bool:
+    """Check if all keys exist in session_state AND are not None.
+
+    Args:
+        *keys: One or more session state keys to check
+
+    Returns:
+        True if all keys exist and have non-None values, False otherwise
+    """
+    return all(
+        key in st.session_state and st.session_state[key] is not None
+        for key in keys
+    )
+
+
+def ss_init(defaults: dict[str, Any]) -> None:
+    """Initialize multiple session_state keys with defaults if they don't exist.
+
+    Args:
+        defaults: Dictionary mapping keys to their default values
+    """
+    for key, default in defaults.items():
+        if key not in st.session_state:
+            st.session_state[key] = default
 
 mkt_db = DatabaseConfig("wcmkt")
 sde_db = DatabaseConfig("sde")


### PR DESCRIPTION
Add three utility functions to simplify session state validation:
- ss_get(key, default): Get value if exists and not None, else default
- ss_has(*keys): Check if all keys exist and are not None
- ss_init(defaults): Bulk initialize keys with defaults if not set

This replaces verbose patterns like:
  if 'key' in st.session_state and st.session_state.key is not None:
with:
  if ss_has('key'):

And bulk initialization patterns (29 lines in build_costs.py) with:
  ss_init({'key1': default1, 'key2': default2, ...})

Files refactored:
- utils.py: Added ss_get, ss_has, ss_init utilities
- pages/build_costs.py: Bulk init from 29 lines to 1 ss_init call
- pages/market_stats.py: 10+ ss_has replacements
- market_metrics.py: ss_has for multi-key checks
- pages/doctrine_status.py: ss_init for state initialization
- pages/doctrine_report.py: ss_init for state initialization
- pages/downloads.py: ss_get for conditional checks
- db_handler.py: ss_get for update time and market data